### PR TITLE
ci: remove unnecessary permission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    env:
-      RUFF_OUTPUT_FORMAT: github
     steps:
       - uses: actions/checkout@v4.2.2
         with:
@@ -116,9 +114,6 @@ jobs:
   markdownlint:
     permissions:
       contents: read
-      # required for upload-sarif action
-      # https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github#example-workflow-for-sarif-files-generated-outside-of-a-repository
-      security-events: write
     uses: opalmedapps/.github/.github/workflows/markdownlint.yaml@main
 
   build-image:

--- a/renovate.json5
+++ b/renovate.json5
@@ -14,7 +14,6 @@
     ":enablePreCommit",
     "github>mschoettle/renovate-presets//presets/docker-alpine.json5",
     "github>mschoettle/renovate-presets//presets/actions-dependency-version.json5",
-    "github>mschoettle/renovate-presets//presets/requires-python.json5",
   ],
   "pip_requirements": {
     "fileMatch": ["^requirements/.*\\.txt$"]


### PR DESCRIPTION
The `security-events` permission is not required by markdownlint.