### PR TITLE
fix: remove foreign key to hospital identifier type for patient hospital identifier

### DIFF
--- a/db_management/opaldb/models.py
+++ b/db_management/opaldb/models.py
@@ -554,6 +554,7 @@ class HospitalMapMH(Base):
 
 class HospitalIdentifierType(Base):
     __tablename__ = 'Hospital_Identifier_Type'
+    __table_args__ = {'comment': 'Deprecated. Superseded by Site model in new admin'}
 
     Hospital_Identifier_Type_Id = Column(INTEGER(11), primary_key=True)
     Code = Column(String(20), nullable=False, unique=True)
@@ -1876,13 +1877,10 @@ class PatientHospitalIdentifier(Base):
 
     Patient_Hospital_Identifier_Id = Column(INTEGER(11), primary_key=True)
     PatientSerNum: Mapped[int] = mapped_column(ForeignKey('Patient.PatientSerNum'), nullable=False, index=True)
-    Hospital_Identifier_Type_Code: Mapped[int] = mapped_column(
-        ForeignKey('Hospital_Identifier_Type.Code'), nullable=False, index=True
-    )
+    Hospital_Identifier_Type_Code = Column(String(20), nullable=False, index=True)
     MRN = Column(String(20), nullable=False, index=True)
     Is_Active = Column(TINYINT(1), nullable=False, server_default=text('1'))
 
-    Hospital_Identifier_Type = relationship('HospitalIdentifierType')
     Patient = relationship('Patient')
 
 

--- a/db_management/opaldb/versions/2025_06_04-5ea831859359_remove_hospital_identifier_type_fk.py
+++ b/db_management/opaldb/versions/2025_06_04-5ea831859359_remove_hospital_identifier_type_fk.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (C) 2025 Opal Health Informatics Group at the Research Institute of the McGill University Health Centre <john.kildea@mcgill.ca>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Remove_the foreign key from Patient_Hospital_Identifier.Hospital_Identifier_Type_Code to Hospital_Identifier_Type.Code.
+
+Replace it with a dedicated column for the code.
+
+Revision ID: 5ea831859359
+Revises: 151fda749fb7
+Create Date: 2025-06-04 17:56:59.085599
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '5ea831859359'
+down_revision = '151fda749fb7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Upgrade the database schema to remove the foreign key constraint and replace it with a char column."""
+    op.create_table_comment(
+        'Hospital_Identifier_Type',
+        'Deprecated. Superseded by Site model in new admin',
+        existing_comment=None,
+        schema=None,
+    )
+    op.drop_constraint('Patient_Hospital_Identifier_ibfk_1', 'Patient_Hospital_Identifier', type_='foreignkey')
+
+
+def downgrade() -> None:
+    """Downgrade the database schema to restore the foreign key constraint and remove the char column."""
+    op.create_foreign_key(
+        'Patient_Hospital_Identifier_ibfk_1',
+        'Patient_Hospital_Identifier',
+        'Hospital_Identifier_Type',
+        ['Hospital_Identifier_Type_Code'],
+        ['Code'],
+    )
+    op.drop_table_comment(
+        'Hospital_Identifier_Type', existing_comment='Deprecated. Superseded by Site model in new admin', schema=None
+    )


### PR DESCRIPTION
The `Hospital_Identifier_Type` table is not used anywhere.
Remove the foreign key constraint to make it easier to insert records.

This table is superseded by the `Site` model in `admin` anyway.