### PR TITLE
fix(data): add missing cronjob OA user

### DIFF
--- a/db_management/opaldb/data/initial/01_initial.sql
+++ b/db_management/opaldb/data/initial/01_initial.sql
@@ -159,7 +159,7 @@ INSERT IGNORE INTO `oaRole` (`ID`, `name_EN`, `name_FR`, `deleted`, `deletedBy`,
 (36,    'ORMS', 'ORMS', 0, '', '2024-03-19 09:22:20', 'AGKE6000', '2024-03-19 09:22:31', 'AGKE6000'),
 (37,	'Medical Records',	'Dossiers médicaux',	0,	'',	'2024-03-19 09:22:20',	'AGKE6000',	'2024-03-19 09:22:20',	'AGKE6000');
 
-INSERT INTO `oaRoleModule` (`ID`, `moduleId`, `oaRoleId`, `access`) VALUES
+INSERT IGNORE INTO `oaRoleModule` (`ID`, `moduleId`, `oaRoleId`, `access`) VALUES
 (1,	1,	1,	3),
 (2,	2,	1,	3),
 (3,	3,	1,	3),


### PR DESCRIPTION
The `cronjob` user is required to run the `resource-pending` and `appointments-pending` scripts. Its ID and name is hardcoded in the config.

It was added in the initial data script in #259 but mistakenly removed later (in https://github.com/opalmedapps/opal-db-management/commit/e1dc73005e54bc3b07b809e528090e5d17b22942).