### PR TITLE
fix(data): set all notifications and data as read

### DIFF
--- a/db_management/opaldb/data/test/omi/omi_announcement.sql
+++ b/db_management/opaldb/data/test/omi/omi_announcement.sql
@@ -62,18 +62,6 @@ WHERE PatientSerNum = 92
 AND NotificationControlSerNum = 5;
 
 -- Update all Announcement dates and read statuses to make the data more similar to a live environment
--- Rorys data read by rory
-UPDATE Announcement
-SET ReadStatus = 1,
-    ReadBy = '["mouj1pqpXrYCl994oSm5wtJT3In2"]'
-WHERE PatientSerNum = 59
-;
-UPDATE Notification
-SET ReadStatus = 1,
-    ReadBy = '["mouj1pqpXrYCl994oSm5wtJT3In2"]'
-WHERE PatientSerNum = 59
-  AND NotificationControlSerNum = 5
-;
 
 -- "Radiation Oncology will be Closed" sent 2 weeks ago
 UPDATE Announcement

--- a/db_management/opaldb/data/test/omi/omi_educationmaterial.sql
+++ b/db_management/opaldb/data/test/omi/omi_educationmaterial.sql
@@ -3,10 +3,9 @@
 -- SPDX-License-Identifier: AGPL-3.0-or-later
 
 INSERT INTO `EducationalMaterial` (`EducationalMaterialSerNum`, `CronLogSerNum`, `EducationalMaterialControlSerNum`, `PatientSerNum`, `DateAdded`, `ReadStatus`, `ReadBy`, `LastUpdated`) VALUES
--- rory: treatment guidelines, databank info, lung guidelines
+-- rory: treatment guidelines, databank info
 (17,	NULL,	105,	59,	'2023-05-15 08:00:55',	0,	'[]',	'2023-01-12 16:39:17'),
 (18,	NULL,	979,	59,	'2023-05-15 08:00:55',	0,	'[]',	'2023-01-12 16:39:17'),
-(19,	NULL,	480,	59,	'2023-05-15 08:00:55',	0,	'[]',	'2023-01-12 16:39:17');
 
 -- Treatment guidelines sent 1 day after diagnosis for all
 
@@ -16,24 +15,7 @@ SET `DateAdded` = DATE_ADD(now(), INTERVAL -13 DAY),
 WHERE PatientSerNum = 59
 AND `EducationalMaterialControlSerNum` = 105;
 
--- Rory's lung guidelines sent 14 days ago
-UPDATE `EducationalMaterial`
-SET `DateAdded` = DATE_ADD(now(), INTERVAL -14 DAY),
-`LastUpdated` = DATE_ADD(now(), INTERVAL -14 DAY)
-WHERE PatientSerNum IN (59)
-AND `EducationalMaterialSerNum` = 19;
-
 -- Remove some notifications
--- Rory has read all their own data
-UPDATE `EducationalMaterial`
-SET ReadStatus = 1,
-    ReadBy = '["mouj1pqpXrYCl994oSm5wtJT3In2"]'
-WHERE PatientSerNum = 59;
-UPDATE Notification
-SET ReadStatus = 1,
-    ReadBy = '["mouj1pqpXrYCl994oSm5wtJT3In2"]'
-WHERE PatientSerNum = 59
-AND NotificationControlSerNum = 7;
 
 -- laurie data
 INSERT INTO `EducationalMaterial` (`EducationalMaterialSerNum`, `CronLogSerNum`, `EducationalMaterialControlSerNum`, `PatientSerNum`, `DateAdded`, `ReadStatus`, `ReadBy`, `LastUpdated`) VALUES
@@ -101,4 +83,4 @@ WHERE `EducationalMaterialControlSerNum` = 979;
 UPDATE `EducationalMaterial`
 SET `DateAdded` = DATE_ADD(now(), INTERVAL -14 DAY),
 `LastUpdated` = DATE_ADD(now(), INTERVAL -14 DAY)
-WHERE `EducationalMaterialControlSerNum` NOT IN (979, 105, 480);
+WHERE `EducationalMaterialControlSerNum` NOT IN (979);

--- a/db_management/opaldb/data/test/omi/omi_questionnaires.sql
+++ b/db_management/opaldb/data/test/omi/omi_questionnaires.sql
@@ -77,7 +77,7 @@ WHERE PatientSerNum = 92
 AND NotificationControlSerNum = 13;
 
 -- Set all other questionnaires sent 2 weeks ago
-UPDATE `EducationalMaterial`
+UPDATE `Questionnaire`
 SET `DateAdded` = DATE_ADD(now(), INTERVAL -14 DAY),
 `LastUpdated` = DATE_ADD(now(), INTERVAL -14 DAY)
-WHERE `EducationalMaterialControlSerNum` NOT IN (157);
+WHERE `QuestionnaireControlSerNum` NOT IN (157);

--- a/db_management/opaldb/data/test/omi/omi_txteammessage.sql
+++ b/db_management/opaldb/data/test/omi/omi_txteammessage.sql
@@ -3,7 +3,6 @@
 -- SPDX-License-Identifier: AGPL-3.0-or-later
 
 INSERT INTO `TxTeamMessage` (`TxTeamMessageSerNum`, `CronLogSerNum`, `PatientSerNum`, `PostControlSerNum`, `DateAdded`, `ReadStatus`, `ReadBy`, `LastUpdated`) VALUES
-(4,	NULL,	59,	13,	'2000-01-01 00:00:00',	0,	'[]',	'2000-01-01 00:00:00'),
 (7, NULL, 92, 13, '2016-12-29 12:15:33', 1, '["a51fba18-3810-4808-9238-4d0e487785c8"]', '2016-12-29 12:18:18'),
 (16, NULL, 92, 22, '2016-12-29 14:25:36', 1, '["a51fba18-3810-4808-9238-4d0e487785c8"]', '2016-12-29 14:37:42'),
 (28, NULL, 92, 28, '2017-07-26 11:16:16', 1, '["a51fba18-3810-4808-9238-4d0e487785c8"]', '2017-07-26 14:24:34'),
@@ -26,44 +25,6 @@ INSERT INTO `TxTeamMessage` (`TxTeamMessageSerNum`, `CronLogSerNum`, `PatientSer
 -- Update all TxTeamMessage dates and read statuses to make the data more similar to a live environment
 
 -- All TxTeamMessages and their Notifications marked as read
--- Marge's data read by Marge
-UPDATE TxTeamMessage
-SET ReadStatus = 1,
-    ReadBy = '["QXmz5ANVN3Qp9ktMlqm2tJ2YYBz2"]'
-WHERE PatientSerNum = 51
-;
-UPDATE Notification
-SET ReadStatus = 1,
-    ReadBy = '["QXmz5ANVN3Qp9ktMlqm2tJ2YYBz2"]'
-WHERE PatientSerNum = 51
-  AND NotificationControlSerNum = 4
-;
-
--- Homer's data read by Homer and Marge
-UPDATE TxTeamMessage
-SET ReadStatus = 1,
-    ReadBy = '["PyKlcbRpMLVm8lVnuopFnFOHO4B3", "QXmz5ANVN3Qp9ktMlqm2tJ2YYBz2"]'
-WHERE PatientSerNum = 52
-;
-UPDATE Notification
-SET ReadStatus = 1,
-    ReadBy = '["PyKlcbRpMLVm8lVnuopFnFOHO4B3", "QXmz5ANVN3Qp9ktMlqm2tJ2YYBz2"]'
-WHERE PatientSerNum = 52
-  AND NotificationControlSerNum = 4
-;
-
--- Bart's data read by Bart and Marge
-UPDATE TxTeamMessage
-SET ReadStatus = 1,
-    ReadBy = '["SipDLZCcOyTYj7O3C8HnWLalb4G3", "QXmz5ANVN3Qp9ktMlqm2tJ2YYBz2"]'
-WHERE PatientSerNum = 53
-;
-UPDATE Notification
-SET ReadStatus = 1,
-    ReadBy = '["SipDLZCcOyTYj7O3C8HnWLalb4G3", "QXmz5ANVN3Qp9ktMlqm2tJ2YYBz2"]'
-WHERE PatientSerNum = 53
-  AND NotificationControlSerNum = 4
-;
 
 -- Welcome Message sent 4 weeks ago
 UPDATE TxTeamMessage
@@ -78,18 +39,6 @@ SET ReadStatus = 1,
 WHERE PatientSerNum = 92
 AND NotificationControlSerNum = 4;
 
--- Rory's data read by Rory
-UPDATE TxTeamMessage
-SET ReadStatus = 1,
-    ReadBy = '["mouj1pqpXrYCl994oSm5wtJT3In2"]'
-WHERE PatientSerNum = 59
-;
-UPDATE Notification
-SET ReadStatus = 1,
-    ReadBy = '["mouj1pqpXrYCl994oSm5wtJT3In2"]'
-WHERE PatientSerNum = 59
-  AND NotificationControlSerNum = 4
-;
 UPDATE TxTeamMessage
 SET DateAdded = DATE_ADD(now(), INTERVAL -14 DAY),
     LastUpdated = DATE_ADD(now(), INTERVAL -14 DAY)

--- a/db_management/opaldb/data/test/z_readstatus.sql
+++ b/db_management/opaldb/data/test/z_readstatus.sql
@@ -1,0 +1,248 @@
+-- SPDX-FileCopyrightText: Copyright (C) 2025 Opal Health Informatics Group at the Research Institute of the McGill University Health Centre <john.kildea@mcgill.ca>
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
+-- Update all read statuses to mimic a live environment and assume that everyone read their data
+-- This is done at the end of inserting all data
+
+-- Rorys data read by rory
+UPDATE Announcement
+SET ReadStatus = 1,
+    ReadBy = '["mouj1pqpXrYCl994oSm5wtJT3In2"]'
+WHERE PatientSerNum = 59
+;
+UPDATE EducationalMaterial
+SET ReadStatus = 1,
+    ReadBy = '["mouj1pqpXrYCl994oSm5wtJT3In2"]'
+WHERE PatientSerNum = 59
+;
+UPDATE Questionnaire
+SET ReadStatus = 1,
+    ReadBy = '["mouj1pqpXrYCl994oSm5wtJT3In2"]'
+WHERE PatientSerNum = 59
+;
+UPDATE TxTeamMessage
+SET ReadStatus = 1,
+    ReadBy = '["mouj1pqpXrYCl994oSm5wtJT3In2"]'
+WHERE PatientSerNum = 59
+;
+UPDATE Notification
+SET ReadStatus = 1,
+    ReadBy = '["mouj1pqpXrYCl994oSm5wtJT3In2"]'
+WHERE PatientSerNum = 59
+;
+
+-- Caras data read by rory and cara
+UPDATE Announcement
+SET ReadStatus = 1,
+    ReadBy = '["mouj1pqpXrYCl994oSm5wtJT3In2", "dR2Cb1Yf0vQb4ywvMoAXw1SxbY93"]'
+WHERE PatientSerNum = 96
+;
+UPDATE EducationalMaterial
+SET ReadStatus = 1,
+    ReadBy = '["mouj1pqpXrYCl994oSm5wtJT3In2", "dR2Cb1Yf0vQb4ywvMoAXw1SxbY93"]'
+WHERE PatientSerNum = 96
+;
+UPDATE Questionnaire
+SET ReadStatus = 1,
+    ReadBy = '["mouj1pqpXrYCl994oSm5wtJT3In2", "dR2Cb1Yf0vQb4ywvMoAXw1SxbY93"]'
+WHERE PatientSerNum = 96
+;
+UPDATE TxTeamMessage
+SET ReadStatus = 1,
+    ReadBy = '["mouj1pqpXrYCl994oSm5wtJT3In2", "dR2Cb1Yf0vQb4ywvMoAXw1SxbY93"]'
+WHERE PatientSerNum = 96
+;
+UPDATE Notification
+SET ReadStatus = 1,
+    ReadBy = '["mouj1pqpXrYCl994oSm5wtJT3In2", "dR2Cb1Yf0vQb4ywvMoAXw1SxbY93"]'
+WHERE PatientSerNum = 96
+;
+
+-- Johns data read by John
+UPDATE Announcement
+SET ReadStatus = 1,
+    ReadBy = '["hIMnEXkedPMxYnXeqNXzphklu4V2"]'
+WHERE PatientSerNum = 93
+;
+UPDATE EducationalMaterial
+SET ReadStatus = 1,
+    ReadBy = '["hIMnEXkedPMxYnXeqNXzphklu4V2"]'
+WHERE PatientSerNum = 93
+;
+UPDATE Questionnaire
+SET ReadStatus = 1,
+    ReadBy = '["hIMnEXkedPMxYnXeqNXzphklu4V2"]'
+WHERE PatientSerNum = 93
+;
+UPDATE TxTeamMessage
+SET ReadStatus = 1,
+    ReadBy = '["hIMnEXkedPMxYnXeqNXzphklu4V2"]'
+WHERE PatientSerNum = 93
+;
+UPDATE Notification
+SET ReadStatus = 1,
+    ReadBy = '["hIMnEXkedPMxYnXeqNXzphklu4V2"]'
+WHERE PatientSerNum = 93
+;
+
+-- Richards data read by John and Richard
+UPDATE Announcement
+SET ReadStatus = 1,
+    ReadBy = '["hIMnEXkedPMxYnXeqNXzphklu4V2", "2WhxeTpYF8aHlfSQX8oGeq4LFhw2"]'
+WHERE PatientSerNum = 94
+;
+UPDATE EducationalMaterial
+SET ReadStatus = 1,
+    ReadBy = '["hIMnEXkedPMxYnXeqNXzphklu4V2", "2WhxeTpYF8aHlfSQX8oGeq4LFhw2"]'
+WHERE PatientSerNum = 94
+;
+UPDATE Questionnaire
+SET ReadStatus = 1,
+    ReadBy = '["hIMnEXkedPMxYnXeqNXzphklu4V2", "2WhxeTpYF8aHlfSQX8oGeq4LFhw2"]'
+WHERE PatientSerNum = 94
+;
+UPDATE TxTeamMessage
+SET ReadStatus = 1,
+    ReadBy = '["hIMnEXkedPMxYnXeqNXzphklu4V2", "2WhxeTpYF8aHlfSQX8oGeq4LFhw2"]'
+WHERE PatientSerNum = 94
+;
+UPDATE Notification
+SET ReadStatus = 1,
+    ReadBy = '["hIMnEXkedPMxYnXeqNXzphklu4V2", "2WhxeTpYF8aHlfSQX8oGeq4LFhw2"]'
+WHERE PatientSerNum = 94
+;
+
+-- Valeries data read by Valerie
+UPDATE Announcement
+SET ReadStatus = 1,
+    ReadBy = '["dcBSK5qdoiOM2L9cEdShkqOadkG3"]'
+WHERE PatientSerNum = 99
+;
+UPDATE EducationalMaterial
+SET ReadStatus = 1,
+    ReadBy = '["dcBSK5qdoiOM2L9cEdShkqOadkG3"]'
+WHERE PatientSerNum = 99
+;
+UPDATE Questionnaire
+SET ReadStatus = 1,
+    ReadBy = '["dcBSK5qdoiOM2L9cEdShkqOadkG3"]'
+WHERE PatientSerNum = 99
+;
+UPDATE TxTeamMessage
+SET ReadStatus = 1,
+    ReadBy = '["dcBSK5qdoiOM2L9cEdShkqOadkG3"]'
+WHERE PatientSerNum = 99
+;
+UPDATE Notification
+SET ReadStatus = 1,
+    ReadBy = '["dcBSK5qdoiOM2L9cEdShkqOadkG3"]'
+WHERE PatientSerNum = 99
+;
+
+-- Petes data read by Pete
+UPDATE Announcement
+SET ReadStatus = 1,
+    ReadBy = '["9kmS7qYQX8arnFFs4ZYJk1tqLFw1"]'
+WHERE PatientSerNum = 100
+;
+UPDATE EducationalMaterial
+SET ReadStatus = 1,
+    ReadBy = '["9kmS7qYQX8arnFFs4ZYJk1tqLFw1"]'
+WHERE PatientSerNum = 100
+;
+UPDATE Questionnaire
+SET ReadStatus = 1,
+    ReadBy = '["9kmS7qYQX8arnFFs4ZYJk1tqLFw1"]'
+WHERE PatientSerNum = 100
+;
+UPDATE TxTeamMessage
+SET ReadStatus = 1,
+    ReadBy = '["9kmS7qYQX8arnFFs4ZYJk1tqLFw1"]'
+WHERE PatientSerNum = 100
+;
+UPDATE Notification
+SET ReadStatus = 1,
+    ReadBy = '["9kmS7qYQX8arnFFs4ZYJk1tqLFw1"]'
+WHERE PatientSerNum = 100
+;
+
+-- Martins data read by Martin
+UPDATE Announcement
+SET ReadStatus = 1,
+    ReadBy = '["2grqcCoyPlVucfAPD4NM1SuCk3i1"]'
+WHERE PatientSerNum = 101
+;
+UPDATE EducationalMaterial
+SET ReadStatus = 1,
+    ReadBy = '["2grqcCoyPlVucfAPD4NM1SuCk3i1"]'
+WHERE PatientSerNum = 101
+;
+UPDATE Questionnaire
+SET ReadStatus = 1,
+    ReadBy = '["2grqcCoyPlVucfAPD4NM1SuCk3i1"]'
+WHERE PatientSerNum = 101
+;
+UPDATE TxTeamMessage
+SET ReadStatus = 1,
+    ReadBy = '["2grqcCoyPlVucfAPD4NM1SuCk3i1"]'
+WHERE PatientSerNum = 101
+;
+UPDATE Notification
+SET ReadStatus = 1,
+    ReadBy = '["2grqcCoyPlVucfAPD4NM1SuCk3i1"]'
+WHERE PatientSerNum = 101
+;
+
+-- Mikes data read by Mike
+UPDATE Announcement
+SET ReadStatus = 1,
+    ReadBy = '["hSJdAae7xWNwnemd2YypQSVfoOb2"]'
+WHERE PatientSerNum = 103
+;
+UPDATE EducationalMaterial
+SET ReadStatus = 1,
+    ReadBy = '["hSJdAae7xWNwnemd2YypQSVfoOb2"]'
+WHERE PatientSerNum = 103
+;
+UPDATE Questionnaire
+SET ReadStatus = 1,
+    ReadBy = '["hSJdAae7xWNwnemd2YypQSVfoOb2"]'
+WHERE PatientSerNum = 103
+;
+UPDATE TxTeamMessage
+SET ReadStatus = 1,
+    ReadBy = '["hSJdAae7xWNwnemd2YypQSVfoOb2"]'
+WHERE PatientSerNum = 103
+;
+UPDATE Notification
+SET ReadStatus = 1,
+    ReadBy = '["hSJdAae7xWNwnemd2YypQSVfoOb2"]'
+WHERE PatientSerNum = 103
+;
+-- Kathys data read by Mike and Kathy
+UPDATE Announcement
+SET ReadStatus = 1,
+    ReadBy = '["hSJdAae7xWNwnemd2YypQSVfoOb2", "OPWj4Cj5iRfgva4b3HGtVGjvuk13"]'
+WHERE PatientSerNum = 102
+;
+UPDATE EducationalMaterial
+SET ReadStatus = 1,
+    ReadBy = '["hSJdAae7xWNwnemd2YypQSVfoOb2", "OPWj4Cj5iRfgva4b3HGtVGjvuk13"]'
+WHERE PatientSerNum = 102
+;
+UPDATE Questionnaire
+SET ReadStatus = 1,
+    ReadBy = '["hSJdAae7xWNwnemd2YypQSVfoOb2", "OPWj4Cj5iRfgva4b3HGtVGjvuk13"]'
+WHERE PatientSerNum = 102
+;
+UPDATE TxTeamMessage
+SET ReadStatus = 1,
+    ReadBy = '["hSJdAae7xWNwnemd2YypQSVfoOb2", "OPWj4Cj5iRfgva4b3HGtVGjvuk13"]'
+WHERE PatientSerNum = 102
+;
+UPDATE Notification
+SET ReadStatus = 1,
+    ReadBy = '["hSJdAae7xWNwnemd2YypQSVfoOb2", "OPWj4Cj5iRfgva4b3HGtVGjvuk13"]'
+WHERE PatientSerNum = 102
+;


### PR DESCRIPTION
Set all notifications and the respective data as read by the respective caregivers.
This is done at the end (last script) so that it happens after all data is inserted.

TBD: How to do this after the other data is pushed in from OpenEMR.

Also removed an educational material for Rory that should not be there.